### PR TITLE
Reuse marshal buffer for Colfer just like done for gencode.

### DIFF
--- a/gosercomp_test.go
+++ b/gosercomp_test.go
@@ -382,13 +382,17 @@ func BenchmarkUnmarshalByGoMemdump(b *testing.B) {
 }
 
 func BenchmarkMarshalByColfer(b *testing.B) {
+	l, _ := colferGroup.MarshalLen()
+	buf := make([]byte, l)
+
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = colferGroup.MarshalBinary()
+		colferGroup.MarshalTo(buf)
 	}
 }
+
 func BenchmarkUnmarshalByColfer(b *testing.B) {
 	result := &ColferColorGroup{}
-
 	buf, _ := colferGroup.MarshalBinary()
 
 	b.ResetTimer()


### PR DESCRIPTION
Now Colfer marshalling is faster than gencode. :-)